### PR TITLE
added rb mode to google api client

### DIFF
--- a/lib/bigquery.rb
+++ b/lib/bigquery.rb
@@ -7,8 +7,8 @@ class BigQuery
   def initialize(opts = {})
     @client = Google::APIClient.new
 
-    key = Google::APIClient::PKCS12.load_key(
-      opts['key'],
+    key = Google::APIClient::PKCS12.load_key(File.open(
+      opts['key'], mode: 'rb'),
       "notasecret"
     )
 


### PR DESCRIPTION
I'm a Ruby newbie so I don't fully understand this issue, but thought I would issue this pull request in case it helps. When I tried to use the original gem, I received an 

```
ArgumentError: Invalid keyfile or passphrase
```

error. The two articles below helped me trace my issue to the way the Google APIClient was working. I made the following change and it worked for me. I am on a Mac OS 10.7.5, using Ruby 2.0, Rails 4.

http://blog.afry.de/2012/12/ruby-meets-google-calendar-api-or-ruby.html
http://stackoverflow.com/questions/10202254/why-openssl-on-windows-produces-error-but-not-on-centos-pkcs12-parse-mac-verif
