### PR TITLE
Add require JSON

### DIFF
--- a/lib/bigquery.rb
+++ b/lib/bigquery.rb
@@ -1,4 +1,5 @@
 require 'google/api_client'
+require 'json'
 
 class BigQuery
 


### PR DESCRIPTION
At Ruby 2.1.1 - uninitialized constant BigQuery::JSON

```
/Users/kkosuge/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bigquery-0.2.9/lib/bigquery.rb:125:in `api': uninitialized constant BigQuery::JSON (NameError)
```
