### PR TITLE
enable a timeout option to be passed to the query method

### DIFF
--- a/lib/bigquery.rb
+++ b/lib/bigquery.rb
@@ -79,13 +79,13 @@ class BigQuery
   # perform a query synchronously
   # fetch all result rows, even when that takes >1 query
   # invoke /block/ once for each row, passing the row
-  def each_row(q, &block)
+  def each_row(q, options = {}, &block)
     current_row = 0
     # repeatedly fetch results, starting from current_row
     # invoke the block on each one, then grab next page if there is one
     # it'll terminate when res has no 'rows' key or when we've done enough rows
     # perform query...
-    res = query(q)
+    res = query(q, options)
     job_id = res['jobReference']['jobId']
     # call the block on the first page of results
     if( res && res['rows'] )


### PR DESCRIPTION
I was getting timeouts for a long-running analysis task, so I added this option.
