### PR TITLE
Add describe_table method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ As this example defines
                      name: { type: 'STRING' } }
     bq.create_table(table_name, table_schema)
 
+Describe table schema
+
+    bq.describe_table('table_name')
+
 ## Query
 
 You can either select
@@ -109,6 +113,24 @@ Now you have everything:
 If you're getting an "invalid_grant" error it usually means your system clock is off.
 
 If you're getting unauthorized requested but you've been able to successfully connect before, you need to refresh your auth by running the "refresh_auth" method.
+
+## How to run test
+
+Before run test, you must create file named `.bigquery_settings.yml` on root of this repository. `.bigquery_settings.yml` must include following infomation.
+
+```yaml
+client_id:     '1234.apps.googleusercontent.com'
+service_email: '1234@developer.gserviceaccount.com'
+key:           '/path/to/somekeyfile-privatekey.p12'
+project_id:    '54321'
+dataset:       'yourdataset'
+```
+
+Then run tests via rake.
+
+```
+$ bundle install && bundle exec rake test
+```
 
 ## Contributing
 

--- a/lib/big_query/client/tables.rb
+++ b/lib/big_query/client/tables.rb
@@ -89,6 +89,19 @@ module BigQuery
         )
       end
 
+      # Describe the schema of the given tableId
+      #
+      # @param tableId [String] table id to describe
+      # @param dataset [String] dataset to look for
+      # @return [Hash] json api response
+      def describe_table(tableId, dataset = @dataset)
+        api(
+          api_method: @bq.tables.get,
+          parameters: { 'tableId' => tableId,
+                        'datasetId' => @dataset }
+        )
+      end
+
       protected
 
       # Translate given schema to a one understandable by bigquery


### PR DESCRIPTION
Add wrapper method of `bigquery.tables.get`. I think this method works like SQL's DESCRIBE command, so I named this as `describe_table`.
- Add method to describe the table schema.
- Change test setup process to create `test` table for easy testing.
- Update README
