### PR TITLE
Added missing data type “TIMESTAMP”

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create table. First param is the table name second one is the table schema defin
 
     {
         field_name: {
-            type: 'TYPE_VALUE BETWEEN (STRING, INTEGER, FLOAT, BOOLEAN, RECORD)',
+            type: 'TYPE_VALUE BETWEEN (STRING, INTEGER, FLOAT, BOOLEAN, RECORD, TIMESTAMP)',
             mode: 'MODE_VALUE BETWEEN (NULLABLE, REQUIRED, REPEATED)'
         },
         other_field_name: { ... }

--- a/lib/big_query/client/tables.rb
+++ b/lib/big_query/client/tables.rb
@@ -4,7 +4,7 @@
 module BigQuery
   class Client
     module Tables
-      ALLOWED_FIELD_TYPES = ['STRING', 'INTEGER', 'FLOAT', 'BOOLEAN', 'RECORD']
+      ALLOWED_FIELD_TYPES = ['STRING', 'INTEGER', 'FLOAT', 'BOOLEAN', 'RECORD', 'TIMESTAMP']
       ALLOWED_FIELD_MODES = ['NULLABLE', 'REQUIRED', 'REPEATED']
 
       # Lists the tables


### PR DESCRIPTION
**Problem**
It doesn't allow me to create a table that contains the `TIMESTAMP` type. It always returns <code>BigQuery::Errors::BigQueryError: Invalid value for: null is not a valid value</code>.

**Solution**
Missing data type “TIMESTAMP” has been added. See [possible data types](http://cloud.google.com/bigquery/preparing-data-for-bigquery#datatypes).
