### PR TITLE
Fix support for RECORD type fields

### DIFF
--- a/lib/big_query/client/tables.rb
+++ b/lib/big_query/client/tables.rb
@@ -108,7 +108,7 @@ module BigQuery
         )
       end
 
-      protected
+      # protected
 
       # Translate given schema to a one understandable by bigquery
       #
@@ -121,6 +121,9 @@ module BigQuery
           mode = (ALLOWED_FIELD_MODES & [options[:mode].to_s]).first
           field = { "name" => name.to_s, "type" => type }
           field["mode"] = mode if mode
+          if field["type"] == 'RECORD'
+            field["fields"] = validate_schema(options[:fields])
+          end
           fields << field
         end
         fields

--- a/lib/big_query/client/tables.rb
+++ b/lib/big_query/client/tables.rb
@@ -108,7 +108,7 @@ module BigQuery
         )
       end
 
-      # protected
+      protected
 
       # Translate given schema to a one understandable by bigquery
       #


### PR DESCRIPTION
It was not supporting RECORD type fields.
Also fixes the test_for_insert_job test.

test_for_tables was changed to select the specific test table, and not just the first returned table. (because there were other tables created).