### PR TITLE
Enable pass faraday option to google-api ruby client

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ service_email: '1234@developer.gserviceaccount.com'
 key:           '/path/to/somekeyfile-privatekey.p12'
 project_id:    '54321'
 dataset:       'yourdataset'
+faraday_option:
+  timeout: 999
 ```
 
 Then run tests via rake.

--- a/lib/big_query/client.rb
+++ b/lib/big_query/client.rb
@@ -15,7 +15,8 @@ module BigQuery
     def initialize(opts = {})
       @client = Google::APIClient.new(
         application_name: 'BigQuery ruby app',
-        application_version: BigQuery::VERSION
+        application_version: BigQuery::VERSION,
+        faraday_option: opts['faraday_option']
       )
 
       key = Google::APIClient::PKCS12.load_key(File.open(

--- a/test/bigquery.rb
+++ b/test/bigquery.rb
@@ -4,6 +4,12 @@ require 'yaml'
 require 'big_query'
 require 'pry-byebug'
 
+module BigQuery
+  class Client
+    attr_accessor :client
+  end
+end
+
 class BigQueryTest < MiniTest::Unit::TestCase
   def setup
     @bq = BigQuery::Client.new(config)
@@ -17,6 +23,10 @@ class BigQueryTest < MiniTest::Unit::TestCase
     return @config if @config
     config_data ||= File.expand_path(File.dirname(__FILE__) + "/../.bigquery_settings.yml")
     @config = YAML.load_file(config_data)
+  end
+
+  def test_faraday_option_config
+    assert_equal @bq.client.connection.options.timeout, 999
   end
 
   def test_for_tables


### PR DESCRIPTION
Query timeout can set by #5, but HTTP timeout cannot set current version.
I got HTTP timeout error when longtime query or large result set.

So I add `faraday_option` and pass it to google-api ruby client.