### PR TITLE
Include insert module

### DIFF
--- a/lib/big_query/client.rb
+++ b/lib/big_query/client.rb
@@ -2,6 +2,7 @@ require 'big_query/client/errors'
 require 'big_query/client/query'
 require 'big_query/client/jobs'
 require 'big_query/client/tables'
+require 'big_query/client/load'
 
 module BigQuery
   class Client
@@ -9,6 +10,7 @@ module BigQuery
     include BigQuery::Client::Query
     include BigQuery::Client::Jobs
     include BigQuery::Client::Tables
+    include BigQuery::Client::Insert
 
     attr_accessor :dataset, :project_id
 


### PR DESCRIPTION
#### Problem
It doesn't work `bq.load(opts)` method.
It always returns `NameError: uninitialized constant module`

#### Solution
`BigQuery::Client` should include `BigQuery::Client::Insert` and require `'big_query/client/load'`.