### PR TITLE
Add support for passing string for key.

### DIFF
--- a/lib/big_query/client.rb
+++ b/lib/big_query/client.rb
@@ -21,10 +21,7 @@ module BigQuery
         faraday_option: opts['faraday_option']
       )
 
-      key = Google::APIClient::PKCS12.load_key(File.open(
-        opts['key'], mode: 'rb'),
-        "notasecret"
-      )
+      key = Google::APIClient::PKCS12.load_key(opts['key'], 'notasecret')
 
       @asserter = Google::APIClient::JWTAsserter.new(
         opts['service_email'],


### PR DESCRIPTION
This will allow one to pass a string for a key instead of a file.

See https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/auth/key_utils.rb#L84