### PR TITLE
Support PEM format keys

### DIFF
--- a/lib/big_query/client.rb
+++ b/lib/big_query/client.rb
@@ -21,7 +21,11 @@ module BigQuery
         faraday_option: opts['faraday_option']
       )
 
-      key = Google::APIClient::PKCS12.load_key(opts['key'], 'notasecret')
+      begin
+        key = Google::APIClient::KeyUtils.load_from_pkcs12(opts['key'], 'notasecret')
+      rescue ArgumentError
+        key = Google::APIClient::KeyUtils.load_from_pem(opts['key'], 'notasecret')
+      end
 
       @client.authorization = Signet::OAuth2::Client.new(
         token_credential_uri: 'https://accounts.google.com/o/oauth2/token',


### PR DESCRIPTION
Google appears to be giving out PEM, not PKCS12 format, keys by default when creating new service accounts. Not sure if this was a recent change or not.

The approach in this PR is obviously not ideal, but I couldn't think of a nice API for this. If you'd like me to add a config option (like "key_format"), let me know.