### PR TITLE
Allow media and parameters when inserting jobs

### DIFF
--- a/lib/big_query/client/jobs.rb
+++ b/lib/big_query/client/jobs.rb
@@ -38,11 +38,15 @@ module BigQuery
 
       # Insert a job
       #
-      # @param options [Hash] hash of job options 
+      # @param options [Hash] hash of job options
+      # @param parameters [Hash] hash of parameters (uploadType, etc.)
+      # @param media [Google::APIClient::UploadIO] media upload
       # @return [Hash] json api response
-      def insert_job(opts)
+      def insert_job(opts, parameters = {}, media = nil)
         api(api_method: @bq.jobs.insert,
-            body_object: {configuration: opts})
+            parameters: parameters,
+            body_object: {configuration: opts},
+            media: media)
       end
     end
   end


### PR DESCRIPTION
This allows us to use this library for uploading data via the Jobs API.

```ruby
    json = StringIO.new
    json.write({ id: 1, name: "me" }.to_json)
    json.write("\n")
    json.rewind

    media = Google::APIClient::UploadIO.new(json, 'application/octet-stream')

    metadata = {
      "load": {
        "sourceFormat": "NEWLINE_DELIMITED_JSON",
        "destinationTable": {
          "projectId": "myproject",
          "datasetId": "mydata",
          "tableId": "mytable"
        }
      }
    }

    result = $bigquery.insert_job(
      metadata,
      { uploadType: 'multipart' },
      media
    )
```