### PR TITLE
Add query options such as useQueryCache, dryRun, maxResults

### DIFF
--- a/lib/big_query/client/query.rb
+++ b/lib/big_query/client/query.rb
@@ -5,14 +5,22 @@ module BigQuery
       #
       # @param given_query [String] query to perform
       # @param options [Hash] query options
-      # @option options [Integer] timeout (90 * 1000) timeout in miliseconds
+      # @option options [Integer] timeout or timeoutMs (90 * 1000) timeout in miliseconds
+      # @option options [Boolean] dryRun Don't actually run this job
+      # @option options [Integer] maxResults The maximum number of rows of data to return per page of results.
+      # @option options [Boolean] useQueryCache Whether to look for the result in the query cache.
       # @return [Hash] json api response
+      # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/query
       def query(given_query, options={})
-        timeout = options.fetch(:timeout, 90 * 1000)
+        body_object = { 'query' => given_query }
+        body_object['timeoutMs']     = options[:timeout] || options[:timeoutMs] || 90 * 1000
+        body_object['maxResults']    = options[:maxResults] if options[:maxResults]
+        body_object['dryRun']        = options[:dryRun] if options.has_key?(:dryRun)
+        body_object['useQueryCache'] = options[:useQueryCache] if options.has_key?(:useQueryCache)
+
         response = api(
           api_method: @bq.jobs.query,
-          body_object: { 'query' => given_query,
-                         'timeoutMs' => timeout}
+          body_object: body_object,
         )
 
         response

--- a/test/bigquery.rb
+++ b/test/bigquery.rb
@@ -120,6 +120,19 @@ class BigQueryTest < MiniTest::Unit::TestCase
     assert_equal result['jobComplete'], true
   end
 
+  def test_for_query_useQueryCache
+    result = @bq.query("SELECT * FROM [#{config['dataset']}.test] LIMIT 1", useQueryCache: true)
+    result = @bq.query("SELECT * FROM [#{config['dataset']}.test] LIMIT 1", useQueryCache: true)
+
+    assert_equal result['cacheHit'], true
+  end
+
+  def test_for_query_dryRun
+    result = @bq.query("SELECT * FROM [#{config['dataset']}.test] LIMIT 1", dryRun: true)
+
+    assert_equal result['jobReference']['jobId'], nil
+  end
+
   def test_for_insert
     result = @bq.insert('test' ,"id" => 123, "type" => "Task")
 


### PR DESCRIPTION
Hi, I wanted to use the `useQueryCache` option for the `query` method, so added it. 
In addition, I added `dryRun` and `maxResults` options. 