### PR TITLE
update google-api-client gem

### DIFF
--- a/bigquery.gemspec
+++ b/bigquery.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency "google-api-client", "~> 0.8.2"
+  s.add_dependency "google-api-client", "0.9.pre1"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
- current google-api-client version causes "invalid_grant" error, updating to current version solves this and allows proper service account authorization