### PR TITLE
Update bigquery.gemspec

### DIFF
--- a/bigquery.gemspec
+++ b/bigquery.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency "google-api-client", "0.9.pre1"
+  s.add_dependency "google-api-client", "0.8.6"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
- meant for that to be 0.8.6, as the main page of the [`google-api-ruby-client` gem shows](https://github.com/google/google-api-ruby-client#migrating-from-08x), migration from 0.8.X to 0.9 takes more config. I'd be happy to work on a PR with those other configs later but for now switching to 0.8.6 should get rid of the `grant_type` error. (I was running the sample code in irb and my local machine's google-api-ruby-client v was 0.8.6 not 0.9)