### PR TITLE
add faraday optionを追加

### DIFF
--- a/lib/big_query/client.rb
+++ b/lib/big_query/client.rb
@@ -15,7 +15,8 @@ module BigQuery
     def initialize(opts = {})
       @client = Google::APIClient.new(
         application_name: 'BigQuery ruby app',
-        application_version: BigQuery::VERSION
+        application_version: BigQuery::VERSION,
+        faraday_option: opts['faraday_option']
       )
 
       key = Google::APIClient::PKCS12.load_key(File.open(


### PR DESCRIPTION
0.5.0にはaddfaraday_optionが無いが、追加する
APIのverが4.2/google-api-clientが0.8.2まで上げることができればこのgemは不要になる