### PR TITLE
Fetch all tables

### DIFF
--- a/lib/big_query/client/tables.rb
+++ b/lib/big_query/client/tables.rb
@@ -14,7 +14,10 @@ module BigQuery
       def tables(dataset = @dataset)
         response = api({
           :api_method => @bq.tables.list,
-          :parameters => {"datasetId" => dataset}
+          :parameters => {
+            "datasetId" => dataset,
+            "maxResults" => 9999999 # default is 50
+          }
         })
 
         response['tables'] || []


### PR DESCRIPTION
By default Google will only return 50 tables.
https://cloud.google.com/bigquery/docs/reference/v2/tables/list

Google API provides no way of filtering the tables in the call.

Fetching a larger number of tables is preferable.

Ideally we would paginate, but I don't see myself fetching so many tables that I would require pagination.

