### PR TITLE
Support optional parameters for Tabledata.list

### DIFF
--- a/lib/big_query/client/tables.rb
+++ b/lib/big_query/client/tables.rb
@@ -35,11 +35,14 @@ module BigQuery
       #
       # @param tableId [String] id of the table to look for
       # @param dataset [String] dataset to look for
+      # @param opts [Hash] hash of optional query parameters (maxResults, startIndex)
       # @return [Hash] json api response
-      def table_data(tableId, dataset = @dataset)
+      def table_data(tableId, dataset = @dataset, options = {})
+        parameters = { 'datasetId' => dataset, 'tableId' => tableId }
+        parameters['maxResults'] = options[:maxResults] if options[:maxResults]
+        parameters['startIndex'] = options[:startIndex] if options[:startIndex]
         response = api(api_method: @bq.tabledata.list,
-                       parameters: { 'datasetId' => dataset,
-                                     'tableId' => tableId })
+                       parameters: parameters)
         response['rows'] || []
       end
 

--- a/lib/big_query/client/tables.rb
+++ b/lib/big_query/client/tables.rb
@@ -35,7 +35,7 @@ module BigQuery
       #
       # @param tableId [String] id of the table to look for
       # @param dataset [String] dataset to look for
-      # @param opts [Hash] hash of optional query parameters (maxResults, startIndex)
+      # @param options [Hash] hash of optional query parameters (maxResults, startIndex)
       # @return [Hash] json api response
       def table_data(tableId, dataset = @dataset, options = {})
         parameters = { 'datasetId' => dataset, 'tableId' => tableId }

--- a/test/bigquery.rb
+++ b/test/bigquery.rb
@@ -48,6 +48,19 @@ class BigQueryTest < MiniTest::Unit::TestCase
     assert_kind_of Array, result
   end
 
+  def test_for_table_data_maxResults
+    result = @bq.table_data('test', @bq.dataset, maxResults: 100)
+
+    assert_kind_of Array, result
+  end
+
+  def test_for_table_data_startIndex
+    # startIndex is Zero-based
+    result = @bq.table_data('test', @bq.dataset, maxResults: 100, startIndex: 100)
+
+    assert_kind_of Array, result
+  end
+
   def test_for_create_table
     if @bq.tables_formatted.include? 'test123'
       @bq.delete_table('test123')


### PR DESCRIPTION
I would like to set the maxResults.
Unfortunately there is a need to specify the startIndex manually to do pagination, Because the current API does not receive the pageToken