### PR TITLE
Support JSON Key file authentication

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     bigquery (0.9.0)
       google-api-client (= 0.9.3)
+      googleauth (>= 0.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,9 +37,9 @@ GEM
       signet (~> 0.7)
     httpclient (2.7.1)
     hurley (0.2)
-    jwt (1.5.3)
+    jwt (1.5.4)
     little-plugger (1.1.4)
-    logging (2.0.0)
+    logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     memoist (0.14.0)

--- a/bigquery.gemspec
+++ b/bigquery.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   s.add_dependency "google-api-client", "0.9.3"
+  s.add_dependency "googleauth", ">=  0.5.0"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
For example:

```ruby
client = BigQuery::Client.new(
    "project_id" => "your-project-42",
    "dataset" =>  "your_dataset",
    "json_key" => "/path/to/somekeyfile.json" # or '{"type": "service_account", ...}'
)
```

When testing,

```yaml
project_id:    '54321'
dataset:       'yourdataset'
json_key:     '/path/to/somekeyfile.json'
faraday_option:
  timeout: 999
```