### PR TITLE
Use pessimistic version constraint

### DIFF
--- a/bigquery.gemspec
+++ b/bigquery.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency "google-api-client", ">= 0.9.3"
-  s.add_dependency "googleauth", ">= 0.5.0"
+  s.add_dependency "google-api-client", "~> 0.9.3"
+  s.add_dependency "googleauth", "~> 0.5.0"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Firstly, Thank you for this great gem! 

I am looking to propose one small change with the dependencies, specifically with the 2 google API gems that are used. I was hoping that we could enforce a pessimistic version constraint on these dependencies.

Why? As you may know both the [Google API Client] and the [Google Auth] gems are in their alpha stages. So any version updates would automatically require us to use the new version, which can be an issue especially since they do not currently guarantee any backward compatibility.

A pessimistic versioning would give us a little more protection from changes that could break from backward compatibility issues, and allow for additional stability.  