### PR TITLE
Bump up version to 0.9.1 and modify CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 0.9.1
+* Support optional query parameters to Datasets.list #34
+* Fetch all tables #35
+* Support optional parameters for Tabledata.list #36
+* Add table_raw_data method #37
+* Update google-api-client #38
+* Support JSON Key file authentication #42
+* Fix bug `insert_all_table_data` #43
+* Follow the version up of google-api-client #44
+* Use pessimitstic version constraint of google-api-client #45
+
+# 0.9.0
+* Add wrapper method of `bigquery.tables.patch` and `bigquery.tables.update` #32
+* Add wrapper method of `biqquery.datasets.list`, `bigquery.datasets.insert` and `bigquery.datasets.delete` #33
+
+# 0.8.3
+* Minor version up google-api-client
+
+# 0.8.2
+* Revert google-api-client version up
+
+# 0.8.1
+* Tweek condition to reduce the query count #23
+* Update google-api-client to `0.9.pre1` #24
+
 # 0.8.0
 * Allow media and parameters when inserting jobs #20
 * Add query options such as useQueryCache, dryRun, maxResults #22

--- a/lib/big_query/version.rb
+++ b/lib/big_query/version.rb
@@ -1,3 +1,3 @@
 module BigQuery
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end


### PR DESCRIPTION
Hi! I'm using your gem usefully :)

It seems that there are a lot of changes, so why do not you release a new version?
(I'd like to use the new version including new version of google-api-client.)

Since the CHANGELOG was outdated, I also updated it.

Would you review it? @abronte 