### PR TITLE
Add support for standard SQL queries

### DIFF
--- a/lib/big_query/client/query.rb
+++ b/lib/big_query/client/query.rb
@@ -9,6 +9,7 @@ module BigQuery
       # @option options [Boolean] dryRun Don't actually run this job
       # @option options [Integer] maxResults The maximum number of rows of data to return per page of results.
       # @option options [Boolean] useQueryCache Whether to look for the result in the query cache.
+      # @option options [Boolean] useLegacySql Whether to use BigQuery's legacy SQL dialect for this query.
       # @return [Hash] json api response
       # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/query
       def query(given_query, options={})
@@ -19,6 +20,7 @@ module BigQuery
         query_request.max_results      = options[:maxResults] if options[:maxResults]
         query_request.dry_run          = options[:dryRun] if options.has_key?(:dryRun)
         query_request.use_query_cache  = options[:useQueryCache] if options.has_key?(:useQueryCache)
+        query_request.use_legacy_sql   = options[:useLegacySql] if options.has_key?(:useLegacySql)
 
         api(
           @client.query_job(

--- a/test/bigquery.rb
+++ b/test/bigquery.rb
@@ -201,6 +201,13 @@ class BigQueryTest < MiniTest::Test
     assert_equal result['jobReference']['jobId'], nil
   end
 
+  def test_for_query_useLegacySql
+    result = @bq.query("SELECT * FROM `#{config['dataset']}.test` LIMIT 1", useLegacySql: false)
+
+    assert_equal result['kind'], "bigquery#queryResponse"
+    assert_equal result['jobComplete'], true
+  end
+
   def test_for_insert
     result = @bq.insert('test' ,"id" => 123, "type" => "Task")
 


### PR DESCRIPTION
Support to queries using [BigQuery's standard SQL dialect](https://cloud.google.com/bigquery/docs/reference/standard-sql/).